### PR TITLE
Containerize for simplified deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Config
 config
+.env
 
 # Backend
 .idea

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+build:
+	$(MAKE) -C marlos-back
+	$(MAKE) -C marlos-front
+
+run:	build
+	docker-compose down
+	docker-compose up -d

--- a/README.md
+++ b/README.md
@@ -10,41 +10,44 @@ A website and tools used to organize D&D encounters.
 - Node serving Vue frontend
 - nginx for reverse proxy
 
+## Running
+
+Configuration via environment variables:
+- MYSQL_DIR: path to mysql persistent files
+- MYSQL_ROOT_PASSWORD: password for mysql backend database
+- KEYCLOAK_DIR: path to keycloak installation files
+- BACKEND_IMAGE: name of backend image
+- FRONTEND_PROD_IMAGE: name of production frontend docker image
+- FRONTEND_TESTING_IMAGE: name of testing frontend docker image
+
+
+Build:
+`make build`
+
+Run:
+`make run`
+
+This will build the back and frontend images (including the testing frontend image) and start them up.
+
+
 ## Frontend
 
 ### Production
 
 To build:
 
-`npm run build`
+`make build-prod`
 
-This will build the files and store them in `marlos-front/dist/`
-
-To serve:
-
-`serve -s dist &`
-
-Will serve on port 5000.
+This will build the production docker image.
 
 
-### Testing live server
+### Testing
 
-View changes in real time -- start the development server. Recommended to start this in a screen session so it can be detached from.
+To build:
 
-`npm run serve -- --port 5500 &`
+`make build-testing`
 
-When changes are saved in Webstorm, changed files are automatically uploaded to the web server. Changes can then be seen at `testing.heatherward.dev`. This is to get around the issue of CORS/requesting things from localhost -> the real backend. Offline development is still problematic; this will hopefully be resolved when I dockerize the components and I can actually run the full stack locally.
-
-Be aware that testing uses the same database as production; changes are real!
-
-
-Build production version (of test deployment):
-
-`npm run build -- --dest dist-testing`
-
-Serve production version (of test deployment):
-
-`serve -l 5500 dist-testing &`
+This will install dependencies and build the testing docker image. Changes to files will go live immediately.
 
 
 ### Tests
@@ -56,10 +59,10 @@ Unit tests are run using Jest:
 
 ## Backend
 
-```
-mvn package
-java -Dorg.apache.el.parser.COERCE_TO_ZERO=false -jar target/marlos.jar
-```
+To build:
+
+`make build`
+
 
 ## Notes
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,38 @@
+version: '3.8'
+services:
+  keycloak:
+    image: openjdk:11
+    restart: unless-stopped
+    network_mode: "host"
+    volumes:
+      - ${KEYCLOAK_DIR}:/keycloak
+    entrypoint: ["/keycloak/bin/standalone.sh", "-Djboss.socket.binding.port-offset=100"]
+  database:
+    image: mysql:8.0
+    restart: unless-stopped
+    network_mode: "host"
+    volumes:
+      - ${MYSQL_DIR}:/var/lib/mysql
+    environment:
+      MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+  backend:
+    image: ${BACKEND_IMAGE}
+    restart: unless-stopped
+    network_mode: "host"
+    depends_on: 
+      - database
+  frontend-prod:
+    image: ${FRONTEND_PROD_IMAGE}
+    restart: unless-stopped
+    network_mode: "host"
+    depends_on:
+      - backend
+  frontend-testing:
+    image: ${FRONTEND_TESTING_IMAGE}
+    restart: unless-stopped
+    network_mode: "host"
+    depends_on:
+      - backend
+    volumes:
+      - ~/Documents/Github_repos/marlos_website/marlos-front:/target

--- a/marlos-back/.gitignore
+++ b/marlos-back/.gitignore
@@ -29,3 +29,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+docker/target

--- a/marlos-back/Dockerfile
+++ b/marlos-back/Dockerfile
@@ -1,0 +1,14 @@
+FROM maven:3.6.3-adoptopenjdk-8 AS builder
+
+WORKDIR /build
+ADD ./src ./src
+ADD ./pom.xml ./
+ADD ./.mvn ./.mvn
+
+RUN mvn package -DskipTests
+
+
+FROM openjdk:11
+COPY --from=builder /build/target/marlos-0.0.1-SNAPSHOT.jar ./marlos.jar
+
+ENTRYPOINT ["java", "-Dorg.apache.el.parser.COERCE_TO_ZERO=false", "-jar", "/marlos.jar"]

--- a/marlos-back/Makefile
+++ b/marlos-back/Makefile
@@ -1,0 +1,9 @@
+export VERSION=$$(git rev-parse --short HEAD)
+export BACKEND_IMAGE="marlos-back:${VERSION}"
+
+build:
+	rm -rf docker/target
+	mkdir -p docker/target
+	cp -r src pom.xml .mvn docker/target
+	cd docker && docker build --rm -t ${BACKEND_IMAGE} .
+

--- a/marlos-back/docker/Dockerfile
+++ b/marlos-back/docker/Dockerfile
@@ -1,9 +1,9 @@
 FROM maven:3.6.3-adoptopenjdk-8 AS builder
 
 WORKDIR /build
-ADD ./src ./src
-ADD ./pom.xml ./
-ADD ./.mvn ./.mvn
+ADD ./target/src ./src
+ADD ./target/pom.xml ./
+ADD ./target/.mvn ./.mvn
 
 RUN mvn package -DskipTests
 

--- a/marlos-back/src/main/resources/application.yml
+++ b/marlos-back/src/main/resources/application.yml
@@ -9,7 +9,7 @@ spring:
         format_sql: true
   datasource:
     driverClassName: "com.mysql.cj.jdbc.Driver"
-    url: jdbc:mysql://localhost:3306/marlos?useSSL=false&serverTimezone=EST5EDT
+    url: jdbc:mysql://localhost:3306/marlos?useSSL=false&serverTimezone=EST5EDT&createDatabaseIfNotExist=true
     username: "root"
     password: ""
 

--- a/marlos-front/.gitignore
+++ b/marlos-front/.gitignore
@@ -1,0 +1,1 @@
+docker/prod/target

--- a/marlos-front/Makefile
+++ b/marlos-front/Makefile
@@ -1,0 +1,15 @@
+export VERSION=$$(git rev-parse --short HEAD)
+export FRONTEND_PROD_IMAGE="marlos-front-prod:${VERSION}"
+export FRONTEND_TESTING_IMAGE="marlos-front-testing:${VERSION}"
+
+build: build-prod build-testing
+
+build-prod:
+	rm -rf docker/prod/target
+	mkdir -p docker/prod/target
+	cp -r package.json src tests docker/prod/target/
+	cd docker/prod && docker build --rm -t ${FRONTEND_PROD_IMAGE} .
+
+build-testing:
+	npm install
+	cd docker/testing && docker build --rm -t ${FRONTEND_TESTING_IMAGE} .

--- a/marlos-front/docker/prod/Dockerfile
+++ b/marlos-front/docker/prod/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:stretch AS builder
+
+WORKDIR /build
+ADD ./target/package.json ./
+ADD ./target/src ./src
+ADD ./target/tests ./tests
+
+RUN npm install
+
+RUN npm run build
+#RUN npm run test:unit
+
+FROM node:stretch-slim
+COPY --from=builder /build/dist /dist
+
+RUN npm install --global serve
+
+ENTRYPOINT ["serve", "-s", "dist"]

--- a/marlos-front/docker/testing/Dockerfile
+++ b/marlos-front/docker/testing/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:stretch-slim
+
+WORKDIR /target
+
+ENTRYPOINT ["npm", "run", "serve", "--", "--port", "5500"]

--- a/marlos-front/package-lock.json
+++ b/marlos-front/package-lock.json
@@ -15676,6 +15676,11 @@
         "iconv-lite": "0.4.24"
       }
     },
+    "whatwg-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.2.0.tgz",
+      "integrity": "sha512-SdGPoQMMnzVYThUbSrEvqTlkvC1Ux27NehaJ/GUHBfNrh5Mjg+1/uRyFMwVnxO2MrikMWvWAqUGgQOfVU4hT7w=="
+    },
     "whatwg-mimetype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-2.3.0.tgz",

--- a/marlos-front/package.json
+++ b/marlos-front/package.json
@@ -24,7 +24,8 @@
     "tiptap-extensions": "^1.28.4",
     "vue": "^2.6.10",
     "vue-router": "^3.0.3",
-    "vuex": "^3.1.1"
+    "vuex": "^3.1.1",
+    "whatwg-fetch": "^3.2.0"
   },
   "devDependencies": {
     "@vue/cli-plugin-babel": "^3.7.0",


### PR DESCRIPTION
Backend and frontend (testing and production) are now built into docker containers, which are deployed behind an nginx reverse-proxy using docker-compose. Keycloak is also incorporated.

Configuration is set using environment variables, and steps can be run using `make` targets.

Closes #14